### PR TITLE
Add script to clip the global layer to an area of interest

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,16 +193,16 @@ Example usage:
 
 ```
 # Clip a country by ISO3 code
-python scripts/analysis/clip-to-boundary.py
-    --iso3 LSO
-    --quarter 2023q4
+python scripts/analysis/clip-to-boundary.py \
+    --iso3 LSO \
+    --quarter 2023q4 \
     --output lesotho_2023q4.tif
 
 # Clip to your own vector file
-python scripts/analysis/clip-to-boundary.py
-    --boundary aoi.gpkg
-    --layer districts
-    --quarter 2020q4
+python scripts/analysis/clip-to-boundary.py \
+    --boundary aoi.gpkg \
+    --layer districts \
+    --quarter 2020q4 \
     --output aoi_2020q4.tif
 ```
 
@@ -215,10 +215,10 @@ will otherwise be evaluated against NoData. Use `--buffer` to keep a margin of r
 around the boundary, given in EPSG:3857 units:
 
 ```
-python scripts/analysis/clip-to-boundary.py
-    --iso3 RWA
-    --quarter 2023q4
-    --buffer 1000
+python scripts/analysis/clip-to-boundary.py \
+    --iso3 RWA \
+    --quarter 2023q4 \
+    --buffer 1000 \
     --output rwanda_2023q4.tif
 ```
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,68 @@ Where `{location}` is one of: `bamako`, `guangdong_province`, `guatemala_departm
 
 ---
 
+## Clipping to an area of interest
+
+The global layer is distributed as thousands of Planet L15 quads, so working with a
+country or region usually means finding the right quads, mosaicking them, and clipping
+the result. We've included a script that does this in one step and writes a single
+two-band COG. See: `scripts/analysis/clip-to-boundary.py`.
+
+Only the tiles overlapping your area of interest are read, and they're streamed directly
+over HTTP with GDAL's `/vsicurl/` driver, so nothing but the tile index is downloaded.
+The output keeps the source CRS, resolution and pixel grid and is resampled with nearest
+neighbour onto a grid-aligned extent, so its pixels are an exact copy of the source plus
+boundary masking.
+
+The area of interest can either be your own vector file (any OGR-readable format,
+reprojected as needed) or a country ISO3 code, in which case the ADM0 boundary is
+downloaded from [fieldmaps.io](https://fieldmaps.io/data/geoboundaries) automatically.
+
+Example usage:
+
+```
+# Clip a country by ISO3 code
+python scripts/analysis/clip-to-boundary.py
+    --iso3 LSO
+    --quarter 2023q4
+    --output lesotho_2023q4.tif
+
+# Clip to your own vector file
+python scripts/analysis/clip-to-boundary.py
+    --boundary aoi.gpkg
+    --layer districts
+    --quarter 2020q4
+    --output aoi_2020q4.tif
+```
+
+Pass `--list-quarters` to see which quarters the tile index currently exposes. The
+quarters are read from the index itself, so newly published layers are picked up without
+updating the script.
+
+Statistics computed near the edge of an area of interest (focal windows, zonal summaries)
+will otherwise be evaluated against NoData. Use `--buffer-m` to keep a margin of real data
+around the boundary:
+
+```
+python scripts/analysis/clip-to-boundary.py
+    --iso3 RWA
+    --quarter 2023q4
+    --buffer-m 1000
+    --output rwanda_2023q4.tif
+```
+
+> **Note:** the buffer is specified as a ground distance in meters. EPSG:3857 is not
+> conformal with respect to the WGS84 ellipsoid, so the script scales the distance by the
+> local meridian scale factor and verifies the result geodesically rather than buffering
+> in projected units directly.
+
+Because this script reads the global tile index, it covers the quarters published in that
+index (currently 2020 Q4 and 2023 Q4) at roughly 76 m/px. For the five locations with a
+quarterly time series, the per-quarter COGs linked above are already clipped and can be
+used directly.
+
+---
+
 ## Model Training
 
 Want to train the model yourself? See **[TRAINING.md](TRAINING.md)** for:

--- a/README.md
+++ b/README.md
@@ -211,21 +211,16 @@ quarters are read from the index itself, so newly published layers are picked up
 updating the script.
 
 Statistics computed near the edge of an area of interest (focal windows, zonal summaries)
-will otherwise be evaluated against NoData. Use `--buffer-m` to keep a margin of real data
-around the boundary:
+will otherwise be evaluated against NoData. Use `--buffer` to keep a margin of real data
+around the boundary, given in EPSG:3857 units:
 
 ```
 python scripts/analysis/clip-to-boundary.py
     --iso3 RWA
     --quarter 2023q4
-    --buffer-m 1000
+    --buffer 1000
     --output rwanda_2023q4.tif
 ```
-
-> **Note:** the buffer is specified as a ground distance in meters. EPSG:3857 is not
-> conformal with respect to the WGS84 ellipsoid, so the script scales the distance by the
-> local meridian scale factor and verifies the result geodesically rather than buffering
-> in projected units directly.
 
 Because this script reads the global tile index, it covers the quarters published in that
 index (currently 2020 Q4 and 2023 Q4) at roughly 76 m/px. For the five locations with a

--- a/scripts/analysis/clip-to-boundary.py
+++ b/scripts/analysis/clip-to-boundary.py
@@ -1,0 +1,437 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Clip the global building density & height layer to an area of interest.
+
+This script takes an area of interest (any OGR-readable vector file, or a country
+ISO3 code), finds the Planet L15 quads covering it in the public GeoPackage tile
+index, mosaics those Cloud-Optimized GeoTIFFs directly over HTTP with GDAL's
+``/vsicurl/`` driver, clips the mosaic to the boundary, and writes a single
+two-band COG. Only the tiles overlapping the area of interest are read, and
+nothing except the index is downloaded to disk.
+
+The output keeps the source CRS (EPSG:3857), resolution and pixel grid, and is
+resampled with nearest neighbour onto a grid-aligned extent, so it is an exact
+copy of the source pixels plus boundary masking.
+
+Output bands match the published dataset:
+    Band 1 = building density (0 to 1, fraction of pixel covered by buildings)
+    Band 2 = building height (0 to 1, multiply by 100 to get meters)
+    NoData = -1
+
+Example usage:
+1.  Clip to a country by ISO3 code (boundary is fetched automatically):
+    python clip-to-boundary.py
+        --iso3 LSO
+        --quarter 2023q4
+        --output lesotho_2023q4.tif
+
+2.  Clip to your own vector file (any OGR format; reprojected as needed):
+    python clip-to-boundary.py
+        --boundary aoi.gpkg
+        --layer districts
+        --quarter 2020q4
+        --output aoi_2020q4.tif
+
+3.  Add a 1 km margin around the boundary so that focal or zonal statistics near
+    the edge are not computed against NoData:
+    python clip-to-boundary.py
+        --iso3 RWA
+        --quarter 2023q4
+        --buffer-m 1000
+        --output rwanda_2023q4.tif
+
+4.  Reuse an already downloaded copy of the tile index:
+    python clip-to-boundary.py
+        --boundary aoi.geojson
+        --quarter 2023q4
+        --index data/tile_index.gpkg
+        --output aoi_2023q4.tif
+
+Run with ``--list-quarters`` to see which quarters the tile index exposes.
+"""
+
+import argparse
+import io
+import math
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.request
+import zipfile
+
+import geopandas as gpd
+import numpy as np
+import pyogrio
+from loguru import logger
+from osgeo import gdal
+from pyproj import CRS, Geod
+from shapely.geometry import LineString
+
+gdal.UseExceptions()
+
+TILE_INDEX_URL = "https://opendata.aiforgood.ai/building-density/tile_index.gpkg"
+DEFAULT_INDEX_PATH = os.path.join("data", "tile_index.gpkg")
+
+# fieldmaps.io redistributes geoBoundaries as ready-to-use GeoPackages. The
+# "originals" archives hold the true national borders; the "extended" archives are
+# edge-matched and deliberately extend past them, so they are not used here.
+GEOBOUNDARIES_URL = "https://data.fieldmaps.io/geoboundaries/originals/{code}.gpkg.zip"
+
+WORKING_CRS = 3857
+NODATA = -1
+BAND_NAMES = ["building_density", "building_height"]
+QUARTER_COLUMN_PREFIX = "data_"
+
+
+def download(url: str, timeout: int = 900) -> bytes:
+    """Fetch a URL, sending an explicit User-Agent.
+
+    Some data hosts reject Python's default urllib User-Agent with HTTP 403.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": "curl/8.0"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def ensure_tile_index(path: str) -> str:
+    """Return a local path to the tile index, downloading it if necessary."""
+    if os.path.exists(path):
+        logger.info(f"Using tile index at {path}")
+        return path
+
+    parent = os.path.dirname(os.path.abspath(path))
+    os.makedirs(parent, exist_ok=True)
+    logger.info(f"Downloading tile index from {TILE_INDEX_URL} (this is a large file)")
+    payload = download(TILE_INDEX_URL)
+    with open(path, "wb") as f:
+        f.write(payload)
+    logger.info(f"Saved tile index to {path}")
+    return path
+
+
+def index_layer(path: str) -> str:
+    """Return the name of the single layer in the tile index GeoPackage."""
+    layers = pyogrio.list_layers(path)
+    if len(layers) != 1:
+        raise SystemExit(f"Expected exactly one layer in {path}, found {len(layers)}")
+    return layers[0][0]
+
+
+def available_quarters(path: str, layer: str) -> list:
+    """List the quarters the tile index exposes, newest last.
+
+    Quarters are discovered from the index schema rather than hard coded, so new
+    releases are picked up without changing this script.
+    """
+    fields = pyogrio.read_info(path, layer=layer)["fields"]
+    quarters = [
+        field[len(QUARTER_COLUMN_PREFIX):]
+        for field in fields
+        if field.startswith(QUARTER_COLUMN_PREFIX)
+    ]
+    return sorted(quarters)
+
+
+def load_geoboundaries_adm0(iso3: str) -> gpd.GeoDataFrame:
+    """Download a country's ADM0 boundary from fieldmaps.io."""
+    code = iso3.lower()
+    url = GEOBOUNDARIES_URL.format(code=code)
+    logger.info(f"Downloading ADM0 boundary for {iso3.upper()} from {url}")
+    archive = zipfile.ZipFile(io.BytesIO(download(url)))
+    name = next(n for n in archive.namelist() if n.endswith(".gpkg"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        local = os.path.join(tmp, os.path.basename(name))
+        with open(local, "wb") as f:
+            f.write(archive.read(name))
+        boundary = gpd.read_file(local, layer=f"{code}_adm0")
+
+    logger.info(f"Boundary has {len(boundary)} feature(s)")
+    return boundary
+
+
+def mercator_meridian_scale(latitude_deg: float) -> float:
+    """Largest ratio of EPSG:3857 units to ground meters at a given latitude.
+
+    EPSG:3857 is not conformal with respect to the WGS84 ellipsoid, so one
+    projected unit corresponds to a different ground distance north-south than
+    east-west::
+
+        parallel scale  k_p(phi) = sec(phi) * sqrt(1 - e^2 sin^2 phi)
+        meridian scale  k_m(phi) = sec(phi) * (1 - e^2 sin^2 phi)^1.5 / (1 - e^2)
+
+    The meridian scale is the larger of the two, so scaling a buffer by it
+    guarantees at least the requested ground distance in every direction.
+    """
+    ellipsoid = CRS.from_epsg(4326).ellipsoid
+    flattening = 1.0 / ellipsoid.inverse_flattening
+    e2 = 2.0 * flattening - flattening**2
+    phi = math.radians(latitude_deg)
+    w = 1.0 - e2 * math.sin(phi) ** 2
+    return w**1.5 / ((1.0 - e2) * math.cos(phi))
+
+
+def measure_margin(original: gpd.GeoDataFrame, buffered: gpd.GeoDataFrame, samples: int = 500):
+    """Geodesic distances from the original boundary out to the buffered boundary."""
+    geod = Geod(ellps="WGS84")
+    border = original.to_crs(4326).geometry.union_all().boundary
+    outline = buffered.to_crs(4326).geometry.union_all().boundary
+
+    rings = [border] if isinstance(border, LineString) else list(border.geoms)
+    longest = max(rings, key=lambda ring: ring.length)
+
+    distances = []
+    for fraction in np.linspace(0, 1, samples, endpoint=False):
+        point = longest.interpolate(fraction, normalized=True)
+        nearest = outline.interpolate(outline.project(point))
+        distances.append(geod.inv(point.x, point.y, nearest.x, nearest.y)[2])
+    return np.array(distances)
+
+
+def buffer_boundary(boundary: gpd.GeoDataFrame, buffer_m: float) -> gpd.GeoDataFrame:
+    """Grow a boundary by a ground distance, working in EPSG:3857."""
+    projected = boundary.to_crs(WORKING_CRS)
+    projected["geometry"] = projected.geometry.make_valid()
+    if buffer_m <= 0:
+        return projected
+
+    bounds = boundary.to_crs(4326).total_bounds
+    latitude = max(abs(bounds[1]), abs(bounds[3]))
+    scale = mercator_meridian_scale(latitude)
+    logger.info(
+        f"Buffering by {buffer_m:,.0f} m ({buffer_m * scale:,.1f} projected units, "
+        f"scale {scale:.5f} at {latitude:.2f} degrees)"
+    )
+
+    projected["geometry"] = projected.geometry.buffer(
+        buffer_m * scale, join_style="round", resolution=32
+    )
+    projected["geometry"] = projected.geometry.make_valid()
+
+    margins = measure_margin(boundary, projected)
+    logger.info(
+        f"Margin around boundary: min {margins.min():,.1f} m, "
+        f"median {np.median(margins):,.1f} m"
+    )
+    return projected
+
+
+def select_tiles(index_path: str, layer: str, boundary: gpd.GeoDataFrame, quarter: str) -> list:
+    """Return the tile URLs for the quads intersecting the boundary."""
+    column = f"{QUARTER_COLUMN_PREFIX}{quarter}"
+    bounds = tuple(boundary.to_crs(WORKING_CRS).total_bounds)
+
+    logger.info("Querying the tile index")
+    tiles = pyogrio.read_dataframe(index_path, layer=layer, bbox=bounds)
+    if column not in tiles.columns:
+        raise SystemExit(f"Tile index has no column {column!r}")
+
+    geometry = boundary.to_crs(tiles.crs).geometry.union_all()
+    tiles = tiles[tiles.geometry.intersects(geometry)]
+    urls = [url for url in tiles[column].tolist() if url]
+
+    logger.info(f"{len(urls)} tiles intersect the area of interest")
+    if not urls:
+        raise SystemExit("No tiles overlap the area of interest")
+    return urls
+
+
+def snap_extent(dataset: gdal.Dataset, boundary: gpd.GeoDataFrame):
+    """Boundary extent clipped to the mosaic and snapped onto its pixel grid."""
+    origin_x, resolution, _, origin_y, _, negative_res = dataset.GetGeoTransform()
+    mosaic_max_x = origin_x + resolution * dataset.RasterXSize
+    mosaic_min_y = origin_y + negative_res * dataset.RasterYSize
+
+    min_x, min_y, max_x, max_y = boundary.to_crs(WORKING_CRS).total_bounds
+    min_x, max_x = max(min_x, origin_x), min(max_x, mosaic_max_x)
+    min_y, max_y = max(min_y, mosaic_min_y), min(max_y, origin_y)
+
+    min_x = origin_x + math.floor((min_x - origin_x) / resolution) * resolution
+    max_x = origin_x + math.ceil((max_x - origin_x) / resolution) * resolution
+    max_y = origin_y - math.floor((origin_y - max_y) / resolution) * resolution
+    min_y = origin_y - math.ceil((origin_y - min_y) / resolution) * resolution
+    return (min_x, min_y, max_x, max_y), resolution
+
+
+def run(command: list) -> None:
+    """Run a GDAL command line tool, raising if it fails."""
+    subprocess.run(command, check=True)
+
+
+def clip(urls: list, boundary: gpd.GeoDataFrame, quarter: str, output: str,
+         buffer_m: float, boundary_source: str) -> None:
+    """Mosaic the tiles, clip them to the boundary and write a COG."""
+    with tempfile.TemporaryDirectory() as tmp:
+        listing = os.path.join(tmp, "tiles.txt")
+        with open(listing, "w") as f:
+            f.write("\n".join(f"/vsicurl/{url}" for url in urls) + "\n")
+
+        cutline = os.path.join(tmp, "cutline.gpkg")
+        boundary.to_crs(WORKING_CRS)[["geometry"]].to_file(
+            cutline, layer="cutline", driver="GPKG"
+        )
+
+        mosaic = os.path.join(tmp, "mosaic.vrt")
+        logger.info("Building a virtual mosaic of the tiles")
+        run([
+            "gdalbuildvrt", "-q", "-input_file_list", listing,
+            "-srcnodata", str(NODATA), "-vrtnodata", str(NODATA), mosaic,
+        ])
+
+        dataset = gdal.Open(mosaic, gdal.GA_Update)
+        if dataset.RasterCount != len(BAND_NAMES):
+            raise SystemExit(
+                f"Expected {len(BAND_NAMES)} bands, found {dataset.RasterCount}"
+            )
+        dataset.SetMetadata({
+            "quarter": quarter,
+            "band_1": "building density: fraction of pixel covered by buildings (0-1)",
+            "band_2": "building height: normalised (0-1), multiply by 100 for meters",
+            "nodata_value": str(NODATA),
+            "boundary_buffer_m": str(buffer_m),
+            "boundary_source": boundary_source,
+            "source_tiles": str(len(urls)),
+            "source": "Microsoft Building Density & Height Dataset",
+        })
+        for position, name in enumerate(BAND_NAMES, start=1):
+            dataset.GetRasterBand(position).SetDescription(name)
+        dataset.FlushCache()
+
+        (min_x, min_y, max_x, max_y), resolution = snap_extent(dataset, boundary)
+        del dataset
+
+        width = int(round((max_x - min_x) / resolution))
+        height = int(round((max_y - min_y) / resolution))
+        logger.info(f"Output grid is {width} x {height} pixels at {resolution:.6f} m")
+
+        clipped = os.path.join(tmp, "clipped.vrt")
+        run([
+            "gdalwarp", "-q", "-overwrite", "-of", "VRT",
+            "-t_srs", f"EPSG:{WORKING_CRS}",
+            "-te", str(min_x), str(min_y), str(max_x), str(max_y),
+            "-tr", str(resolution), str(resolution),
+            "-r", "near",
+            "-cutline", cutline, "-cl", "cutline",
+            "-srcnodata", str(NODATA), "-dstnodata", str(NODATA),
+            mosaic, clipped,
+        ])
+
+        logger.info(f"Writing {output}")
+        parent = os.path.dirname(os.path.abspath(output))
+        os.makedirs(parent, exist_ok=True)
+        run([
+            "gdal_translate", "-q", "-of", "COG",
+            "-co", "COMPRESS=DEFLATE", "-co", "PREDICTOR=3",
+            "-co", "BIGTIFF=IF_SAFER", "-co", "NUM_THREADS=ALL_CPUS",
+            "-co", "RESAMPLING=AVERAGE",
+            clipped, output,
+        ])
+
+    size_mb = os.path.getsize(output) / 1e6
+    logger.info(f"Wrote {output} ({size_mb:,.1f} MB)")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Clip the global building density & height layer to an area of interest "
+            "and write a single two-band Cloud-Optimized GeoTIFF."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "--boundary",
+        help="Vector file describing the area of interest (any OGR-readable format)",
+    )
+    source.add_argument(
+        "--iso3",
+        help="ISO3 country code; the ADM0 boundary is downloaded from fieldmaps.io",
+    )
+    parser.add_argument(
+        "--layer", help="Layer to read from --boundary (defaults to the first layer)"
+    )
+    parser.add_argument("--quarter", help="Quarter to clip, for example 2023q4")
+    parser.add_argument("--output", help="Path of the GeoTIFF to write")
+    parser.add_argument(
+        "--index",
+        default=DEFAULT_INDEX_PATH,
+        help="Local path of the tile index; it is downloaded here if missing",
+    )
+    parser.add_argument(
+        "--buffer-m",
+        type=float,
+        default=0.0,
+        help="Optional margin in meters to keep around the boundary",
+    )
+    parser.add_argument(
+        "--list-quarters",
+        action="store_true",
+        help="Print the quarters available in the tile index and exit",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Streaming many small COGs over HTTP is much faster when GDAL does not probe
+    # sibling files and caches the ranges it reads.
+    gdal.SetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "EMPTY_DIR")
+    gdal.SetConfigOption("CPL_VSIL_CURL_ALLOWED_EXTENSIONS", ".tif")
+    gdal.SetConfigOption("GDAL_HTTP_MAX_RETRY", "3")
+    gdal.SetConfigOption("GDAL_HTTP_RETRY_DELAY", "1")
+    for key in (
+        "GDAL_DISABLE_READDIR_ON_OPEN",
+        "CPL_VSIL_CURL_ALLOWED_EXTENSIONS",
+        "GDAL_HTTP_MAX_RETRY",
+        "GDAL_HTTP_RETRY_DELAY",
+    ):
+        os.environ.setdefault(key, gdal.GetConfigOption(key))
+
+    index_path = ensure_tile_index(args.index)
+    layer = index_layer(index_path)
+    quarters = available_quarters(index_path, layer)
+
+    if args.list_quarters:
+        print("Quarters available in the tile index:")
+        for quarter in quarters:
+            print(f"  {quarter}")
+        return
+
+    if not args.boundary and not args.iso3:
+        raise SystemExit("Provide either --boundary or --iso3")
+    if not args.quarter:
+        raise SystemExit(f"Provide --quarter (one of: {', '.join(quarters)})")
+    if not args.output:
+        raise SystemExit("Provide --output")
+    if args.quarter not in quarters:
+        raise SystemExit(
+            f"Quarter {args.quarter!r} is not in the tile index "
+            f"(available: {', '.join(quarters)})"
+        )
+    if args.layer and not args.boundary:
+        raise SystemExit("--layer only applies to --boundary")
+
+    if args.iso3:
+        boundary = load_geoboundaries_adm0(args.iso3)
+        boundary_source = f"geoBoundaries ADM0 ({args.iso3.upper()}) via fieldmaps.io"
+    else:
+        boundary = gpd.read_file(args.boundary, layer=args.layer)
+        boundary_source = os.path.basename(args.boundary)
+        logger.info(f"Read {len(boundary)} feature(s) from {args.boundary}")
+
+    if boundary.empty:
+        raise SystemExit("The area of interest is empty")
+    if boundary.crs is None:
+        raise SystemExit("The area of interest has no CRS; please set one")
+
+    boundary = buffer_boundary(boundary, args.buffer_m)
+    urls = select_tiles(index_path, layer, boundary, args.quarter)
+    clip(urls, boundary, args.quarter, args.output, args.buffer_m, boundary_source)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analysis/clip-to-boundary.py
+++ b/scripts/analysis/clip-to-boundary.py
@@ -54,6 +54,7 @@ import argparse
 import io
 import math
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -69,11 +70,16 @@ from loguru import logger
 TILE_INDEX_URL = "https://opendata.aiforgood.ai/building-density/tile_index.gpkg"
 DEFAULT_INDEX_PATH = os.path.join("data", "tile_index.gpkg")
 GEOBOUNDARIES_URL = "https://data.fieldmaps.io/geoboundaries/originals/{code}.gpkg.zip"
+USER_AGENT = "curl/8.0"
 
 WORKING_CRS = 3857
 NODATA = -1
 BAND_NAMES = ("building_density", "building_height")
 QUARTER_COLUMN_PREFIX = "data_"
+
+# Snapping compares coordinates that are many millions of meters from the origin, so
+# allow a little floating point slack before rounding a grid position outwards.
+GRID_TOLERANCE = 1e-6
 
 # Streaming many small COGs is much faster when GDAL does not probe for sibling files.
 GDAL_HTTP_OPTIONS = {
@@ -86,21 +92,37 @@ GDAL_HTTP_OPTIONS = {
 
 def download(url: str, timeout: int = 900) -> bytes:
     """Fetch a URL. Some hosts reject the default urllib User-Agent."""
-    request = urllib.request.Request(url, headers={"User-Agent": "curl/8.0"})
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     with urllib.request.urlopen(request, timeout=timeout) as response:
         return response.read()
 
 
-def ensure_tile_index(path: str) -> str:
-    """Return a local path to the tile index, downloading it if necessary."""
+def ensure_tile_index(path: str, timeout: int = 900) -> str:
+    """Return a local path to the tile index, downloading it if necessary.
+
+    The index is streamed to a temporary file and moved into place once it is
+    complete, so an interrupted download cannot leave a truncated file behind that
+    later runs would mistake for a usable index.
+    """
     if os.path.exists(path):
         logger.info(f"Using tile index at {path}")
         return path
 
-    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
     logger.info(f"Downloading tile index from {TILE_INDEX_URL} (this is a large file)")
-    with open(path, "wb") as f:
-        f.write(download(TILE_INDEX_URL))
+
+    request = urllib.request.Request(TILE_INDEX_URL, headers={"User-Agent": USER_AGENT})
+    handle, partial = tempfile.mkstemp(dir=directory, suffix=".partial")
+    try:
+        with os.fdopen(handle, "wb") as f:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                shutil.copyfileobj(response, f)
+    except BaseException:
+        os.unlink(partial)
+        raise
+
+    os.replace(partial, path)
     logger.info(f"Saved tile index to {path}")
     return path
 
@@ -147,6 +169,14 @@ def load_geoboundaries_adm0(iso3: str) -> gpd.GeoDataFrame:
 
 def prepare_boundary(boundary: gpd.GeoDataFrame, buffer: float) -> gpd.GeoDataFrame:
     """Reproject the boundary to the working CRS and optionally buffer it."""
+    min_x, _, max_x, _ = boundary.to_crs(4326).total_bounds
+    if max_x - min_x > 180:
+        raise SystemExit(
+            "The area of interest spans more than 180 degrees of longitude, which usually "
+            "means it crosses the antimeridian. EPSG:3857 cannot represent that as one "
+            "contiguous extent; clip each side of the antimeridian separately."
+        )
+
     projected = boundary.to_crs(WORKING_CRS)
     projected["geometry"] = projected.geometry.make_valid()
 
@@ -154,6 +184,9 @@ def prepare_boundary(boundary: gpd.GeoDataFrame, buffer: float) -> gpd.GeoDataFr
         logger.info(f"Buffering the boundary by {buffer:,.1f} projected units")
         projected["geometry"] = projected.geometry.buffer(buffer).make_valid()
 
+    projected = projected[~projected.geometry.is_empty]
+    if projected.empty:
+        raise SystemExit("The area of interest has no geometry after preparation")
     return projected
 
 
@@ -170,10 +203,41 @@ def select_tiles(index_path: str, layer: str, boundary: gpd.GeoDataFrame, quarte
     tiles = tiles[tiles.geometry.intersects(geometry)]
     urls = [url for url in tiles[column].tolist() if url]
 
+    missing = len(tiles) - len(urls)
+    if missing:
+        logger.warning(
+            f"{missing} of {len(tiles)} quads have no {quarter} tile and will be left as NoData"
+        )
+
     logger.info(f"{len(urls)} tiles intersect the area of interest")
     if not urls:
         raise SystemExit("No tiles overlap the area of interest")
     return urls
+
+
+def snap_steps(distance: float, resolution: float, mode: str) -> int:
+    """Convert a distance to whole pixels, rounding outwards past float noise."""
+    steps = distance / resolution
+    nearest = round(steps)
+    if math.isclose(steps, nearest, rel_tol=0.0, abs_tol=GRID_TOLERANCE):
+        return nearest
+    return math.floor(steps) if mode == "floor" else math.ceil(steps)
+
+
+def validate_mosaic(dataset) -> None:
+    """Check the mosaic matches the grid assumptions the output relies on."""
+    if dataset.count != len(BAND_NAMES):
+        raise SystemExit(f"Expected {len(BAND_NAMES)} bands, found {dataset.count}")
+    if dataset.crs is None or dataset.crs.to_epsg() != WORKING_CRS:
+        raise SystemExit(f"Expected EPSG:{WORKING_CRS} tiles, found {dataset.crs}")
+
+    transform = dataset.transform
+    if transform.b or transform.d:
+        raise SystemExit("Rotated tiles are not supported")
+    if transform.a <= 0 or transform.e >= 0:
+        raise SystemExit("Expected north-up tiles")
+    if not math.isclose(transform.a, -transform.e, rel_tol=1e-9):
+        raise SystemExit("Expected square pixels")
 
 
 def snap_extent(dataset, boundary: gpd.GeoDataFrame):
@@ -182,14 +246,26 @@ def snap_extent(dataset, boundary: gpd.GeoDataFrame):
     origin_x, origin_y = dataset.transform.c, dataset.transform.f
     mosaic = dataset.bounds
 
-    min_x, min_y, max_x, max_y = boundary.total_bounds
-    min_x, max_x = max(min_x, mosaic.left), min(max_x, mosaic.right)
-    min_y, max_y = max(min_y, mosaic.bottom), min(max_y, mosaic.top)
+    requested = boundary.total_bounds
+    min_x, max_x = max(requested[0], mosaic.left), min(requested[2], mosaic.right)
+    min_y, max_y = max(requested[1], mosaic.bottom), min(requested[3], mosaic.top)
+    if min_x >= max_x or min_y >= max_y:
+        raise SystemExit("The area of interest does not overlap the available tiles")
 
-    min_x = origin_x + math.floor((min_x - origin_x) / resolution) * resolution
-    max_x = origin_x + math.ceil((max_x - origin_x) / resolution) * resolution
-    max_y = origin_y - math.floor((origin_y - max_y) / resolution) * resolution
-    min_y = origin_y - math.ceil((origin_y - min_y) / resolution) * resolution
+    if any(
+        abs(a - b) > GRID_TOLERANCE
+        for a, b in ((min_x, requested[0]), (min_y, requested[1]),
+                     (max_x, requested[2]), (max_y, requested[3]))
+    ):
+        logger.warning(
+            "The area of interest extends beyond the available tiles; "
+            "the output covers the overlapping part only"
+        )
+
+    min_x = origin_x + snap_steps(min_x - origin_x, resolution, "floor") * resolution
+    max_x = origin_x + snap_steps(max_x - origin_x, resolution, "ceil") * resolution
+    max_y = origin_y - snap_steps(origin_y - max_y, resolution, "floor") * resolution
+    min_y = origin_y - snap_steps(origin_y - min_y, resolution, "ceil") * resolution
     return (min_x, min_y, max_x, max_y), resolution
 
 
@@ -211,14 +287,15 @@ def clip(urls: list, boundary: gpd.GeoDataFrame, quarter: str, output: str,
 
         mosaic = os.path.join(tmp, "mosaic.vrt")
         logger.info("Building a virtual mosaic of the tiles")
+        # -strict so an unreachable tile fails the run instead of silently
+        # leaving a NoData hole in the output.
         run([
-            "gdalbuildvrt", "-q", "-input_file_list", listing,
+            "gdalbuildvrt", "-q", "-strict", "-input_file_list", listing,
             "-srcnodata", str(NODATA), "-vrtnodata", str(NODATA), mosaic,
         ])
 
         with rasterio.open(mosaic) as dataset:
-            if dataset.count != len(BAND_NAMES):
-                raise SystemExit(f"Expected {len(BAND_NAMES)} bands, found {dataset.count}")
+            validate_mosaic(dataset)
             (min_x, min_y, max_x, max_y), resolution = snap_extent(dataset, boundary)
 
         width = int(round((max_x - min_x) / resolution))
@@ -254,16 +331,25 @@ def clip(urls: list, boundary: gpd.GeoDataFrame, quarter: str, output: str,
 
         logger.info(f"Writing {output}")
         os.makedirs(os.path.dirname(os.path.abspath(output)), exist_ok=True)
-        rasterio.shutil.copy(
-            clipped,
-            output,
-            driver="COG",
-            COMPRESS="DEFLATE",
-            PREDICTOR=3,
-            BIGTIFF="IF_SAFER",
-            NUM_THREADS="ALL_CPUS",
-            RESAMPLING="AVERAGE",
-        )
+        # Write beside the destination and move it into place, so a failure part
+        # way through does not leave a half written raster behind.
+        partial = f"{output}.partial"
+        try:
+            rasterio.shutil.copy(
+                clipped,
+                partial,
+                driver="COG",
+                COMPRESS="DEFLATE",
+                PREDICTOR=3,
+                BIGTIFF="IF_SAFER",
+                NUM_THREADS="ALL_CPUS",
+                RESAMPLING="AVERAGE",
+            )
+        except BaseException:
+            if os.path.exists(partial):
+                os.unlink(partial)
+            raise
+        os.replace(partial, output)
 
     logger.info(f"Wrote {output} ({os.path.getsize(output) / 1e6:,.1f} MB)")
 
@@ -336,8 +422,8 @@ def main() -> None:
         )
     if args.layer and not args.boundary:
         raise SystemExit("--layer only applies to --boundary")
-    if args.buffer < 0:
-        raise SystemExit("--buffer must not be negative")
+    if not math.isfinite(args.buffer) or args.buffer < 0:
+        raise SystemExit("--buffer must be a finite, non-negative number")
 
     if args.iso3:
         boundary = load_geoboundaries_adm0(args.iso3)

--- a/scripts/analysis/clip-to-boundary.py
+++ b/scripts/analysis/clip-to-boundary.py
@@ -33,12 +33,11 @@ Example usage:
         --quarter 2020q4
         --output aoi_2020q4.tif
 
-3.  Add a 1 km margin around the boundary so that focal or zonal statistics near
-    the edge are not computed against NoData:
+3.  Keep a margin of data around the boundary, in projected units:
     python clip-to-boundary.py
         --iso3 RWA
         --quarter 2023q4
-        --buffer-m 1000
+        --buffer 1000
         --output rwanda_2023q4.tif
 
 4.  Reuse an already downloaded copy of the tile index:
@@ -62,34 +61,31 @@ import urllib.request
 import zipfile
 
 import geopandas as gpd
-import numpy as np
 import pyogrio
+import rasterio
+import rasterio.shutil
 from loguru import logger
-from osgeo import gdal
-from pyproj import CRS, Geod
-from shapely.geometry import LineString
-
-gdal.UseExceptions()
 
 TILE_INDEX_URL = "https://opendata.aiforgood.ai/building-density/tile_index.gpkg"
 DEFAULT_INDEX_PATH = os.path.join("data", "tile_index.gpkg")
-
-# fieldmaps.io redistributes geoBoundaries as ready-to-use GeoPackages. The
-# "originals" archives hold the true national borders; the "extended" archives are
-# edge-matched and deliberately extend past them, so they are not used here.
 GEOBOUNDARIES_URL = "https://data.fieldmaps.io/geoboundaries/originals/{code}.gpkg.zip"
 
 WORKING_CRS = 3857
 NODATA = -1
-BAND_NAMES = ["building_density", "building_height"]
+BAND_NAMES = ("building_density", "building_height")
 QUARTER_COLUMN_PREFIX = "data_"
+
+# Streaming many small COGs is much faster when GDAL does not probe for sibling files.
+GDAL_HTTP_OPTIONS = {
+    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+    "CPL_VSIL_CURL_ALLOWED_EXTENSIONS": ".tif",
+    "GDAL_HTTP_MAX_RETRY": "3",
+    "GDAL_HTTP_RETRY_DELAY": "1",
+}
 
 
 def download(url: str, timeout: int = 900) -> bytes:
-    """Fetch a URL, sending an explicit User-Agent.
-
-    Some data hosts reject Python's default urllib User-Agent with HTTP 403.
-    """
+    """Fetch a URL. Some hosts reject the default urllib User-Agent."""
     request = urllib.request.Request(url, headers={"User-Agent": "curl/8.0"})
     with urllib.request.urlopen(request, timeout=timeout) as response:
         return response.read()
@@ -101,12 +97,10 @@ def ensure_tile_index(path: str) -> str:
         logger.info(f"Using tile index at {path}")
         return path
 
-    parent = os.path.dirname(os.path.abspath(path))
-    os.makedirs(parent, exist_ok=True)
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     logger.info(f"Downloading tile index from {TILE_INDEX_URL} (this is a large file)")
-    payload = download(TILE_INDEX_URL)
     with open(path, "wb") as f:
-        f.write(payload)
+        f.write(download(TILE_INDEX_URL))
     logger.info(f"Saved tile index to {path}")
     return path
 
@@ -120,18 +114,17 @@ def index_layer(path: str) -> str:
 
 
 def available_quarters(path: str, layer: str) -> list:
-    """List the quarters the tile index exposes, newest last.
+    """List the quarters the tile index exposes.
 
-    Quarters are discovered from the index schema rather than hard coded, so new
-    releases are picked up without changing this script.
+    These are read from the index schema rather than hard coded, so new releases
+    are picked up without changing this script.
     """
     fields = pyogrio.read_info(path, layer=layer)["fields"]
-    quarters = [
+    return sorted(
         field[len(QUARTER_COLUMN_PREFIX):]
         for field in fields
         if field.startswith(QUARTER_COLUMN_PREFIX)
-    ]
-    return sorted(quarters)
+    )
 
 
 def load_geoboundaries_adm0(iso3: str) -> gpd.GeoDataFrame:
@@ -152,79 +145,24 @@ def load_geoboundaries_adm0(iso3: str) -> gpd.GeoDataFrame:
     return boundary
 
 
-def mercator_meridian_scale(latitude_deg: float) -> float:
-    """Largest ratio of EPSG:3857 units to ground meters at a given latitude.
-
-    EPSG:3857 is not conformal with respect to the WGS84 ellipsoid, so one
-    projected unit corresponds to a different ground distance north-south than
-    east-west::
-
-        parallel scale  k_p(phi) = sec(phi) * sqrt(1 - e^2 sin^2 phi)
-        meridian scale  k_m(phi) = sec(phi) * (1 - e^2 sin^2 phi)^1.5 / (1 - e^2)
-
-    The meridian scale is the larger of the two, so scaling a buffer by it
-    guarantees at least the requested ground distance in every direction.
-    """
-    ellipsoid = CRS.from_epsg(4326).ellipsoid
-    flattening = 1.0 / ellipsoid.inverse_flattening
-    e2 = 2.0 * flattening - flattening**2
-    phi = math.radians(latitude_deg)
-    w = 1.0 - e2 * math.sin(phi) ** 2
-    return w**1.5 / ((1.0 - e2) * math.cos(phi))
-
-
-def measure_margin(original: gpd.GeoDataFrame, buffered: gpd.GeoDataFrame, samples: int = 500):
-    """Geodesic distances from the original boundary out to the buffered boundary."""
-    geod = Geod(ellps="WGS84")
-    border = original.to_crs(4326).geometry.union_all().boundary
-    outline = buffered.to_crs(4326).geometry.union_all().boundary
-
-    rings = [border] if isinstance(border, LineString) else list(border.geoms)
-    longest = max(rings, key=lambda ring: ring.length)
-
-    distances = []
-    for fraction in np.linspace(0, 1, samples, endpoint=False):
-        point = longest.interpolate(fraction, normalized=True)
-        nearest = outline.interpolate(outline.project(point))
-        distances.append(geod.inv(point.x, point.y, nearest.x, nearest.y)[2])
-    return np.array(distances)
-
-
-def buffer_boundary(boundary: gpd.GeoDataFrame, buffer_m: float) -> gpd.GeoDataFrame:
-    """Grow a boundary by a ground distance, working in EPSG:3857."""
+def prepare_boundary(boundary: gpd.GeoDataFrame, buffer: float) -> gpd.GeoDataFrame:
+    """Reproject the boundary to the working CRS and optionally buffer it."""
     projected = boundary.to_crs(WORKING_CRS)
     projected["geometry"] = projected.geometry.make_valid()
-    if buffer_m <= 0:
-        return projected
 
-    bounds = boundary.to_crs(4326).total_bounds
-    latitude = max(abs(bounds[1]), abs(bounds[3]))
-    scale = mercator_meridian_scale(latitude)
-    logger.info(
-        f"Buffering by {buffer_m:,.0f} m ({buffer_m * scale:,.1f} projected units, "
-        f"scale {scale:.5f} at {latitude:.2f} degrees)"
-    )
+    if buffer > 0:
+        logger.info(f"Buffering the boundary by {buffer:,.1f} projected units")
+        projected["geometry"] = projected.geometry.buffer(buffer).make_valid()
 
-    projected["geometry"] = projected.geometry.buffer(
-        buffer_m * scale, join_style="round", resolution=32
-    )
-    projected["geometry"] = projected.geometry.make_valid()
-
-    margins = measure_margin(boundary, projected)
-    logger.info(
-        f"Margin around boundary: min {margins.min():,.1f} m, "
-        f"median {np.median(margins):,.1f} m"
-    )
     return projected
 
 
 def select_tiles(index_path: str, layer: str, boundary: gpd.GeoDataFrame, quarter: str) -> list:
     """Return the tile URLs for the quads intersecting the boundary."""
     column = f"{QUARTER_COLUMN_PREFIX}{quarter}"
-    bounds = tuple(boundary.to_crs(WORKING_CRS).total_bounds)
 
     logger.info("Querying the tile index")
-    tiles = pyogrio.read_dataframe(index_path, layer=layer, bbox=bounds)
+    tiles = pyogrio.read_dataframe(index_path, layer=layer, bbox=tuple(boundary.total_bounds))
     if column not in tiles.columns:
         raise SystemExit(f"Tile index has no column {column!r}")
 
@@ -238,15 +176,15 @@ def select_tiles(index_path: str, layer: str, boundary: gpd.GeoDataFrame, quarte
     return urls
 
 
-def snap_extent(dataset: gdal.Dataset, boundary: gpd.GeoDataFrame):
+def snap_extent(dataset, boundary: gpd.GeoDataFrame):
     """Boundary extent clipped to the mosaic and snapped onto its pixel grid."""
-    origin_x, resolution, _, origin_y, _, negative_res = dataset.GetGeoTransform()
-    mosaic_max_x = origin_x + resolution * dataset.RasterXSize
-    mosaic_min_y = origin_y + negative_res * dataset.RasterYSize
+    resolution = dataset.transform.a
+    origin_x, origin_y = dataset.transform.c, dataset.transform.f
+    mosaic = dataset.bounds
 
-    min_x, min_y, max_x, max_y = boundary.to_crs(WORKING_CRS).total_bounds
-    min_x, max_x = max(min_x, origin_x), min(max_x, mosaic_max_x)
-    min_y, max_y = max(min_y, mosaic_min_y), min(max_y, origin_y)
+    min_x, min_y, max_x, max_y = boundary.total_bounds
+    min_x, max_x = max(min_x, mosaic.left), min(max_x, mosaic.right)
+    min_y, max_y = max(min_y, mosaic.bottom), min(max_y, mosaic.top)
 
     min_x = origin_x + math.floor((min_x - origin_x) / resolution) * resolution
     max_x = origin_x + math.ceil((max_x - origin_x) / resolution) * resolution
@@ -261,7 +199,7 @@ def run(command: list) -> None:
 
 
 def clip(urls: list, boundary: gpd.GeoDataFrame, quarter: str, output: str,
-         buffer_m: float, boundary_source: str) -> None:
+         buffer: float, boundary_source: str) -> None:
     """Mosaic the tiles, clip them to the boundary and write a COG."""
     with tempfile.TemporaryDirectory() as tmp:
         listing = os.path.join(tmp, "tiles.txt")
@@ -269,9 +207,7 @@ def clip(urls: list, boundary: gpd.GeoDataFrame, quarter: str, output: str,
             f.write("\n".join(f"/vsicurl/{url}" for url in urls) + "\n")
 
         cutline = os.path.join(tmp, "cutline.gpkg")
-        boundary.to_crs(WORKING_CRS)[["geometry"]].to_file(
-            cutline, layer="cutline", driver="GPKG"
-        )
+        boundary[["geometry"]].to_file(cutline, layer="cutline", driver="GPKG")
 
         mosaic = os.path.join(tmp, "mosaic.vrt")
         logger.info("Building a virtual mosaic of the tiles")
@@ -280,27 +216,10 @@ def clip(urls: list, boundary: gpd.GeoDataFrame, quarter: str, output: str,
             "-srcnodata", str(NODATA), "-vrtnodata", str(NODATA), mosaic,
         ])
 
-        dataset = gdal.Open(mosaic, gdal.GA_Update)
-        if dataset.RasterCount != len(BAND_NAMES):
-            raise SystemExit(
-                f"Expected {len(BAND_NAMES)} bands, found {dataset.RasterCount}"
-            )
-        dataset.SetMetadata({
-            "quarter": quarter,
-            "band_1": "building density: fraction of pixel covered by buildings (0-1)",
-            "band_2": "building height: normalised (0-1), multiply by 100 for meters",
-            "nodata_value": str(NODATA),
-            "boundary_buffer_m": str(buffer_m),
-            "boundary_source": boundary_source,
-            "source_tiles": str(len(urls)),
-            "source": "Microsoft Building Density & Height Dataset",
-        })
-        for position, name in enumerate(BAND_NAMES, start=1):
-            dataset.GetRasterBand(position).SetDescription(name)
-        dataset.FlushCache()
-
-        (min_x, min_y, max_x, max_y), resolution = snap_extent(dataset, boundary)
-        del dataset
+        with rasterio.open(mosaic) as dataset:
+            if dataset.count != len(BAND_NAMES):
+                raise SystemExit(f"Expected {len(BAND_NAMES)} bands, found {dataset.count}")
+            (min_x, min_y, max_x, max_y), resolution = snap_extent(dataset, boundary)
 
         width = int(round((max_x - min_x) / resolution))
         height = int(round((max_y - min_y) / resolution))
@@ -318,19 +237,35 @@ def clip(urls: list, boundary: gpd.GeoDataFrame, quarter: str, output: str,
             mosaic, clipped,
         ])
 
-        logger.info(f"Writing {output}")
-        parent = os.path.dirname(os.path.abspath(output))
-        os.makedirs(parent, exist_ok=True)
-        run([
-            "gdal_translate", "-q", "-of", "COG",
-            "-co", "COMPRESS=DEFLATE", "-co", "PREDICTOR=3",
-            "-co", "BIGTIFF=IF_SAFER", "-co", "NUM_THREADS=ALL_CPUS",
-            "-co", "RESAMPLING=AVERAGE",
-            clipped, output,
-        ])
+        # The COG driver is copy-only, so band names and metadata are set on the
+        # clipped VRT first; reopening the finished COG would break its layout.
+        with rasterio.open(clipped, "r+") as dataset:
+            dataset.descriptions = BAND_NAMES
+            dataset.update_tags(
+                quarter=quarter,
+                band_1="building density: fraction of pixel covered by buildings (0-1)",
+                band_2="building height: normalised (0-1), multiply by 100 for meters",
+                nodata_value=str(NODATA),
+                boundary_buffer=str(buffer),
+                boundary_source=boundary_source,
+                source_tiles=str(len(urls)),
+                source="Microsoft Building Density & Height Dataset",
+            )
 
-    size_mb = os.path.getsize(output) / 1e6
-    logger.info(f"Wrote {output} ({size_mb:,.1f} MB)")
+        logger.info(f"Writing {output}")
+        os.makedirs(os.path.dirname(os.path.abspath(output)), exist_ok=True)
+        rasterio.shutil.copy(
+            clipped,
+            output,
+            driver="COG",
+            COMPRESS="DEFLATE",
+            PREDICTOR=3,
+            BIGTIFF="IF_SAFER",
+            NUM_THREADS="ALL_CPUS",
+            RESAMPLING="AVERAGE",
+        )
+
+    logger.info(f"Wrote {output} ({os.path.getsize(output) / 1e6:,.1f} MB)")
 
 
 def parse_args() -> argparse.Namespace:
@@ -361,10 +296,10 @@ def parse_args() -> argparse.Namespace:
         help="Local path of the tile index; it is downloaded here if missing",
     )
     parser.add_argument(
-        "--buffer-m",
+        "--buffer",
         type=float,
         default=0.0,
-        help="Optional margin in meters to keep around the boundary",
+        help="Margin to keep around the boundary, in EPSG:3857 units",
     )
     parser.add_argument(
         "--list-quarters",
@@ -376,20 +311,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-
-    # Streaming many small COGs over HTTP is much faster when GDAL does not probe
-    # sibling files and caches the ranges it reads.
-    gdal.SetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "EMPTY_DIR")
-    gdal.SetConfigOption("CPL_VSIL_CURL_ALLOWED_EXTENSIONS", ".tif")
-    gdal.SetConfigOption("GDAL_HTTP_MAX_RETRY", "3")
-    gdal.SetConfigOption("GDAL_HTTP_RETRY_DELAY", "1")
-    for key in (
-        "GDAL_DISABLE_READDIR_ON_OPEN",
-        "CPL_VSIL_CURL_ALLOWED_EXTENSIONS",
-        "GDAL_HTTP_MAX_RETRY",
-        "GDAL_HTTP_RETRY_DELAY",
-    ):
-        os.environ.setdefault(key, gdal.GetConfigOption(key))
+    os.environ.update(GDAL_HTTP_OPTIONS)
 
     index_path = ensure_tile_index(args.index)
     layer = index_layer(index_path)
@@ -414,6 +336,8 @@ def main() -> None:
         )
     if args.layer and not args.boundary:
         raise SystemExit("--layer only applies to --boundary")
+    if args.buffer < 0:
+        raise SystemExit("--buffer must not be negative")
 
     if args.iso3:
         boundary = load_geoboundaries_adm0(args.iso3)
@@ -428,9 +352,9 @@ def main() -> None:
     if boundary.crs is None:
         raise SystemExit("The area of interest has no CRS; please set one")
 
-    boundary = buffer_boundary(boundary, args.buffer_m)
+    boundary = prepare_boundary(boundary, args.buffer)
     urls = select_tiles(index_path, layer, boundary, args.quarter)
-    clip(urls, boundary, args.quarter, args.output, args.buffer_m, boundary_source)
+    clip(urls, boundary, args.quarter, args.output, args.buffer, boundary_source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds `scripts/analysis/clip-to-boundary.py`, which turns the global tile index into a single
two-band COG for an area of interest, plus a README section documenting it.

The global layer ships as thousands of Planet L15 quads, so using it for a country or region
currently means locating the right quads, mosaicking them and clipping the result. This does
that in one step:

```bash
python scripts/analysis/clip-to-boundary.py --iso3 LSO --quarter 2023q4 --output lesotho.tif
```

## Design notes

- **Nothing is bulk downloaded.** Only the tiles overlapping the AOI are read, streamed over
  HTTP with `/vsicurl/`. Just the tile index is fetched to disk (into the gitignored `data/`).
- **Pixel-exact output.** The target CRS, resolution and pixel grid all match the source, the
  extent is snapped outward onto the source grid, and resampling is nearest neighbour — so the
  result is a copy of the source pixels plus boundary masking, with no half-pixel shift.
- **Quarters are discovered from the index schema** (`data_*` columns) rather than hard coded,
  so when new quarters are published the script picks them up unchanged. `--list-quarters`
  prints what's currently available.
- **Boundary input** is either any OGR-readable vector (`--boundary`, optional `--layer`) or a
  country code (`--iso3`), which pulls the geoBoundaries ADM0 from fieldmaps.io.
- **`--buffer`** optionally keeps a margin of data around the AOI, in EPSG:3857 units, so that
  focal or zonal statistics near the edge aren't computed against NoData. Off by default.
- **rasterio** is used to read the mosaic's grid, set band names and metadata, and write the
  COG. `gdalbuildvrt` and `gdalwarp` are invoked as command line tools so the mosaic is never
  held in memory. Note that metadata has to be set on the clipped VRT rather than on the
  finished file, because the COG driver is copy-only and reopening the output would break its
  layout.

Follows the conventions in `scripts/`: MIT header, `argparse`, module docstring with usage
examples, `loguru`. No new dependencies beyond what `requirements-scripts.txt` already lists,
plus the GDAL command line tools.

## Testing

- Lesotho, both published quarters — 139 tiles, 3564x3532 at 76.437 m/px. Output validates as
  a COG (`validate_cloud_optimized_geotiff.py`), with two correctly named bands, NoData -1,
  overviews and metadata tags present.
- Pixel-exactness — read a source tile straight from its public URL and compared it against the
  same footprint in the output: identical values, max absolute difference 0.0 over 131,070
  pixels inside the cutline.
- `--buffer 1000` — tile count grows 139 -> 142 and the grid by ~26 px (1000 / 76.437), as
  expected. Negative values are rejected.
- Both boundary modes, `--layer` selection, mutual exclusion of `--boundary`/`--iso3`, unknown
  quarter rejection, a single-tile AOI, and an AOI with no coverage (clean error, no traceback).

## Notes for reviewers

- The `--iso3` convenience is the only third-party network dependency (fieldmaps.io) and is
  isolated to one function. Happy to drop it and keep `--boundary` only if you'd prefer the
  repo not reach out to a third-party host.
- Unrelated to this change: the README describes the global layer as "~100 m/px", but the
  published tiles are 256x256 per quad at ~76.4 m/px. Left alone here — happy to fix it in a
  separate PR if that wording should change.
